### PR TITLE
feat: A dot prefix to active menu items

### DIFF
--- a/assets/scss/layouts/_sidebar.scss
+++ b/assets/scss/layouts/_sidebar.scss
@@ -110,7 +110,7 @@ a.docs-link {
   left: 0;
   top: 50%;
   margin-top: -5px;
-  background-color: currentcolor;
+  background-color: currentColor;
   -webkit-animation: scalein 0.7s forwards;
   animation: scalein 0.7s forwards;
 }

--- a/assets/scss/layouts/_sidebar.scss
+++ b/assets/scss/layouts/_sidebar.scss
@@ -111,9 +111,9 @@ a.docs-link {
   left: 0px;
   top: 50%;
   margin-top: -5px;
-  background-color: $link-color;
-  -webkit-animation: scaleIn .7s forwards;
-  animation: scaleIn .7s forwards;
+  background-color: currentcolor;
+  -webkit-animation: scalein .7s forwards;
+  animation: scalein .7s forwards;
 }
 
 .docs-links h3.sidebar-link,

--- a/assets/scss/layouts/_sidebar.scss
+++ b/assets/scss/layouts/_sidebar.scss
@@ -85,15 +85,15 @@ a.docs-link {
   font-size: $font-size-base * 0.9375;
 }
 
+.docs-link {
+  transition: all .3s;
+}
+
 .docs-link:hover,
 .docs-link.active,
 .page-links a:hover {
   text-decoration: none;
   color: $link-color;
-}
-
-.docs-link {
-  transition: all .3s;
 }
 
 .docs-link.active{

--- a/assets/scss/layouts/_sidebar.scss
+++ b/assets/scss/layouts/_sidebar.scss
@@ -86,7 +86,7 @@ a.docs-link {
 }
 
 .docs-link {
-  transition: all .3s;
+  transition: all 0.3s;
 }
 
 .docs-link:hover,
@@ -96,24 +96,23 @@ a.docs-link {
   color: $link-color;
 }
 
-.docs-link.active{
+.docs-link.active {
   position: relative;
-  padding-left: .8rem;
+  padding-left: 0.8rem;
 }
 
-
-.docs-link.active:before {
+.docs-link.active::before {
   content: " ";
   width: 8px;
   height: 8px;
   border-radius: 10px;
   position: absolute;
-  left: 0px;
+  left: 0;
   top: 50%;
   margin-top: -5px;
   background-color: currentcolor;
-  -webkit-animation: scalein .7s forwards;
-  animation: scalein .7s forwards;
+  -webkit-animation: scalein 0.7s forwards;
+  animation: scalein 0.7s forwards;
 }
 
 .docs-links h3.sidebar-link,

--- a/assets/scss/layouts/_sidebar.scss
+++ b/assets/scss/layouts/_sidebar.scss
@@ -92,6 +92,30 @@ a.docs-link {
   color: $link-color;
 }
 
+.docs-link {
+  transition: all .3s;
+}
+
+.docs-link.active{
+  position: relative;
+  padding-left: .8rem;
+}
+
+
+.docs-link.active:before {
+  content: " ";
+  width: 8px;
+  height: 8px;
+  border-radius: 10px;
+  position: absolute;
+  left: 0px;
+  top: 50%;
+  margin-top: -5px;
+  background-color: $link-color;
+  -webkit-animation: scaleIn .7s forwards;
+  animation: scaleIn .7s forwards;
+}
+
 .docs-links h3.sidebar-link,
 .page-links h3.sidebar-link {
   text-transform: none;


### PR DESCRIPTION
@h-enk Talking about the Doks origin and plans in one of  the discussions, I am guessing this would be in the Doks roadmaps.

Differentiate active menu item from rest, by prefixing a dot or circle symbol. 

<img width="316" alt="Screenshot 2021-02-22 at 10 15 32 PM" src="https://user-images.githubusercontent.com/5073326/108740252-7deba100-755b-11eb-9275-f33fe7f18dbc.png">

If not please ignore and reject. Thanks