### PR TITLE
Add table support in markdown

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -19,6 +19,7 @@
 @import "components/forms";
 @import "components/images";
 @import "components/search";
+@import "components/tables";
 @import "layouts/footer";
 @import "layouts/header";
 @import "layouts/pages";

--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -291,3 +291,7 @@ body.dark .alert-primary {
 body.dark .figure-caption {
   color: $body-color-dark;
 }
+
+body.dark table {
+  @extend .table-dark;
+}

--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -1,0 +1,5 @@
+table {
+  @extend .table;
+
+  margin: 3rem 0;
+}

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -45,6 +45,12 @@ rel  = "sitemap"
   [markup.goldmark]
     [markup.goldmark.extensions]
       linkify = false
+    [markup.goldmark.parser]
+      autoHeadingID = true
+      autoHeadingIDType = "github"
+      [markup.goldmark.parser.attribute]
+        block = true
+        title = true
     [markup.goldmark.renderer]
       unsafe = true
   [markup.highlight]

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -8,10 +8,16 @@ module.exports = {
     purgecss({
       content: [
         './layouts/**/*.html',
-        './content/**/*.md',      
+        './content/**/*.md',
       ],
       safelist: [
         'lazyloaded',
+        'table',
+        'thead',
+        'tbody',
+        'tr',
+        'th',
+        'td',
         ...whitelister([
           './assets/scss/components/_code.scss',
           './assets/scss/components/_search.scss',


### PR DESCRIPTION
Example:

```md
| Tables   |      Are      |  Cool |
|----------|:-------------:|------:|
| col 1 is |  left-aligned | $1600 |
| col 2 is |    centered   |   $12 |
| col 3 is | right-aligned |    $1 |
{.table-striped}
```

Light mode:

![Snag_165c1e0](https://user-images.githubusercontent.com/3902872/110121752-13d6c580-7dbf-11eb-8093-0a6fe3d7188e.png)

Dark mode:

![Snag_165cd0b](https://user-images.githubusercontent.com/3902872/110121760-15a08900-7dbf-11eb-8bdb-dc16be5bdad4.png)
