### PR TITLE
Add optional breadcrumb trail

### DIFF
--- a/assets/scss/layouts/_pages.scss
+++ b/assets/scss/layouts/_pages.scss
@@ -38,3 +38,8 @@ p.meta {
   margin-top: 0.5rem;
   font-size: $font-size-base;
 }
+
+.breadcrumb {
+  margin-top: 2.25rem;
+  font-size: $font-size-base;
+}

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -53,3 +53,4 @@ editPage = false
   flexSearch = true
   darkMode = true
   bootStrapJs = false
+  breadCrumb = false

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -3,7 +3,7 @@
 		<div class="col-lg-5 col-xl-4 docs-sidebar">
 			<nav class="docs-links" aria-label="Main navigation">
 				{{ partial "sidebar/docs-menu.html" . }}
-			</nav>        
+			</nav>
 		</div>
 		{{ if ne .Params.toc false -}}
 		<nav class="docs-toc d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
@@ -15,6 +15,15 @@
 		{{ else -}}
 		<main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
 		{{ end -}}
+			{{ if .Site.Params.options.breadCrumb -}}
+				<!-- https://discourse.gohugo.io/t/breadcrumb-navigation-for-highly-nested-content/27359/6 -->
+				<nav aria-label="breadcrumb">
+					<ol class="breadcrumb">
+						{{ partial "main/breadcrumb" . -}}
+						<li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+					</ol>
+				</nav>
+			{{ end }}
 			<h1>{{ .Title }}</h1>
 			<p class="lead">{{ .Params.lead | safeHTML }}</p>
 			{{ partial "main/headline-hash.html" .Content }}

--- a/layouts/partials/main/breadcrumb.html
+++ b/layouts/partials/main/breadcrumb.html
@@ -1,0 +1,4 @@
+{{ with .Parent -}}
+  {{ partial "main/breadcrumb.html" . -}}
+  <li class="breadcrumb-item"><a href="{{ .Permalink }}">{{ if .IsHome }}Home{{ else }}{{ .Title }}{{ end }}</a></li>
+{{ end -}}


### PR DESCRIPTION
Set in `./config/_default/params.toml`:

```toml
[options]
  breadCrumb = true
```

Example:

![Snag_2d29ad1](https://user-images.githubusercontent.com/3902872/110167918-bf4f3c80-7df6-11eb-9826-1fd18e29287a.png)

Markup:

```html
<nav aria-label="breadcrumb">
  <ol class="breadcrumb">
    <li class="breadcrumb-item"><a href="//localhost:1313/">Home</a></li>
    <li class="breadcrumb-item"><a href="//localhost:1313/docs/">Docs</a></li>
    <li class="breadcrumb-item"><a href="//localhost:1313/docs/prologue/">Prologue</a></li>
    <li class="breadcrumb-item active" aria-current="page">Introduction</li>
  </ol>
</nav>
```
Note: this is an optional user breadcrumb trail — next to the already implemented JSON-LD for [rich results](https://developers.google.com/search/docs/data-types/breadcrumb):

```json
{
  "@context":"http://schema.org",
  "@type":"BreadcrumbList",
  "itemListElement":[
    {
      "@type":"ListItem",
      "position":1,
      "name":"Home",
      "item":"https:\/\/getdoks.org"
    },
    {
      "@type":"ListItem",
      "position":3,
      "name":"Docs",
      "item":"https:\/\/getdoks.org\/docs\/"
    },
    {
      "@type":"ListItem",
      "position":4,
      "name":"Prologue",
      "item":"https:\/\/getdoks.org\/docs\/prologue\/"
    },
    {
      "@type":"ListItem",
      "position":5,
      "name":"Introduction",
      "item":"https:\/\/getdoks.org\/docs\/prologue\/introduction\/"
    }
  ]
}
```