### PR TITLE
fix: tokenize for CJK characters

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -80,6 +80,9 @@ Source:
           'description',
         ],
     },
+    tokenize: function(str) {
+        return str.split(/\W+/).concat(str.replace(/[\x00-\x7F]/g, '').split('')).filter(e => !!e)
+    }
   });
 
   var docs = [


### PR DESCRIPTION
Hi, current flexIndex configuration doesn't support tokenizing the word for CJK characters.

And I changed the tokenize configuration, it works.

