### PR TITLE
Fix issue where page bundle images fail to load

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -10,7 +10,7 @@
 {{ end -}}
 
 {{ range $widths -}}
-  {{ $srcUrl := (printf "%dx" . | $image.Resize).RelPermalink -}}
+  {{ $srcUrl := (printf "%dx" . | $image.Resize).Permalink -}}
   {{ if eq $imgSrc "" -}}{{ $imgSrc = $srcUrl -}}{{ end -}}
   {{ $imgSrcSet = $imgSrcSet | append (printf "%s %dw" $srcUrl .) -}}
 {{ end -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@hyas/doks",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.13",


### PR DESCRIPTION
First of all, I just want to say thanks for the awesome theme.

I noticed an issue where images in page bundles fail to load if the site is not deployed to the root. For example, if you deploy the site to _www.example.com/projects/info_.

To reproduce the issue, in the `say-hello-to-doks` blog post embed the `say-hello-to-doks.png` and run a build. 

![image](https://user-images.githubusercontent.com/47948499/115034715-cf4c4880-9e99-11eb-8ead-45edc0a2a545.png)

Checking out the resulting `index.html`, the first entry in `data-srcset` has an absolute URL but the rest are relative URL's. The relative links will fail to load once deployed since the default config is using canonical URL's with a baseURL.

![image](https://user-images.githubusercontent.com/47948499/115034755-db380a80-9e99-11eb-9f08-52b304d5f29b.png)

This seems because `RelPermalink` is used in the `img` shortcode. Switch to `Permalink` and rebuild to fix the issue.

![image](https://user-images.githubusercontent.com/47948499/115035388-88128780-9e9a-11eb-978a-39a011a81b5c.png)

![image](https://user-images.githubusercontent.com/47948499/115034883-fc006000-9e99-11eb-8773-119edbc65ddf.png)


