### PR TITLE
Replace highlightBlock with highlightElement

### DIFF
--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -19,6 +19,6 @@ hljs.registerLanguage('md', markdown);
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('pre code').forEach((block) => {
-    hljs.highlightBlock(block);
+    hljs.highlightElement(block);
   });
 });


### PR DESCRIPTION
Replace deprecated API with new API.

<img width="500" alt="スクリーンショット 2021-04-18 19 14 07" src="https://user-images.githubusercontent.com/72645163/115143448-51976100-a082-11eb-92e8-98f6cc26ada7.png">

For further information, please refer to [h-enk/doks - Issue #239](https://github.com/h-enk/doks/issues/239)