### PR TITLE
Fix lint tests on Linux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "npm run -s lint:scripts && npm run -s lint:styles && npm run -s lint:markdown",
     "lint:scripts": "eslint assets/js config functions",
     "lint:styles": "stylelint \"assets/scss/**/*.{css,sass,scss,sss,less}\"",
-    "lint:markdown": "markdownlint *.md content/**/*.md",
+    "lint:markdown": "markdownlint \"*.md\" \"content/**/*.md\"",
     "server": "exec-bin bin/hugo/hugo server",
     "test": "npm run -s lint",
     "env": "env",


### PR DESCRIPTION
markdownlint command was not doing anything on Linux. It worked fine in Windows. This fix addresses and now it is working on both operating systems. Please refer to https://github.com/igorshubovych/markdownlint-cli#globbing-examples and notice that the command requires quotes on Linux.