### PR TITLE
added scroll position lock for sidebar

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,5 +23,6 @@
     {{ block "sidebar-footer" . }}{{ end }}
     {{ partial "footer/footer.html" . }}
     {{ partial "footer/script-footer.html" . }}
+    {{ partial "footer/scroll-position.html" . }}
   </body>
 </html>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 	<div class="row flex-xl-nowrap">
 		<div class="col-lg-5 col-xl-4 docs-sidebar d-none d-lg-block">
-			<nav class="docs-links" aria-label="Main navigation">
+			<nav class="docs-links" id="sidebar" aria-label="Main navigation">
 				{{ partial "sidebar/docs-menu.html" . }}
 			</nav>
 		</div>

--- a/layouts/partials/footer/scroll-position.html
+++ b/layouts/partials/footer/scroll-position.html
@@ -1,0 +1,12 @@
+<script>
+    let sidebar = document.getElementById("sidebar");
+
+    let pos = sessionStorage.getItem("sidebar-scroll");
+    if (pos !== null) {
+        sidebar.scrollTop = parseInt(pos, 10);
+    }
+
+    window.addEventListener("beforeunload", () => {
+        sessionStorage.setItem("sidebar-scroll", sidebar.scrollTop);
+    });
+</script>


### PR DESCRIPTION
This change makes the sidebar remember its scroll position when navigating the docs.
This is only useful for sidebars that are long and have their own scroll i.e. if `collapsibleSidebar = false`