### PR TITLE
Add .Summary as fallback for description

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -104,7 +104,11 @@ Source:
         id: {{ $index }},
         href: "{{ .RelPermalink }}",
         title: {{ .Title | jsonify }},
-        description: {{ .Params.description | jsonify }},
+        {{ with .Description -}}
+          description: {{ . | jsonify }},
+        {{ else -}}
+          description: {{ .Summary | plainify | jsonify }},
+        {{ end -}}
         content: {{ .Content | jsonify }}
       })
       {{ if ne (add $index 1) $len -}}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -19,7 +19,11 @@
 {{ with .Description -}}
   <meta name="description" content="{{ . }}">
 {{ else -}}
-  <meta name="description" content="{{ .Site.Params.description }}">
+  {{ with .Summary | plainify -}}
+    <meta name="description" content="{{ . }}">
+  {{ else -}}
+    <meta name="description" content="{{ .Site.Params.description }}">
+  {{ end -}}
 {{ end -}}
 
 {{ if $.Scratch.Get "paginator" }}


### PR DESCRIPTION
When the `.Description` of a page is not set, it's good practice useful to fallback to the Hugo-generated `.Summary` value. See also: https://gohugo.io/variables/page/

I have added the fallback to the `flexsearch` descriptions and description `meta` tag. I briefly looked at other places where `.Description is used`:

- `layouts/_default/index.js`
- `layouts/_default/index.json`

However, I can't say if it makes sense to also add a fallback there, as well.