### PR TITLE
Plainify flexsearch index values

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -108,7 +108,7 @@ Source:
         {{ else -}}
           description: {{ .Summary | plainify | jsonify }},
         {{ end -}}
-        content: {{ .Content | jsonify }}
+        content: {{ .Plain | jsonify }}
       })
       {{ if ne (add $index 1) $len -}}
         .add(


### PR DESCRIPTION
Currently, the flexsearch index is populated with the non-planified `.Content` page variable.

You can try searching for the following and be able to find results: `<div class="alert alert-warning d-flex"` which is not part of the actual content but rather rendered HTML.

Using `.Plain` fixes this:

> **.Plain**
>  the Page content stripped of HTML tags and presented as a string.
> — https://gohugo.io/variables/page/

I inserted the following in `content/en/docs/prolouge/commands.md` to test whether you can search for HTML tags that are part of the actual content:

````markdown
### styles

Check styles for errors:

```html
npm run lint:styles [-- --fix]
<div class="test">foobar</div>
```
````

And it works:

- `<div class="test">foo` returns a search result
- `<div class="alert alert-warning d-flex"` doesn't return search results

On top of that the resulting `index.js` is way smaller:

- development: 32.2 kB -> 15.3 kB (~27% smaller)
- production: 15.3 kB -> 7 kB (~54% smaller)
