### PR TITLE
#535 - Bug fix. Handle missing images in render-image.html.

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,4 +1,6 @@
 {{ $image := .Page.Resources.GetMatch .Destination -}}
+{{ with $image -}}
+
 {{ $lqip := $image.Resize site.Params.lqipWidth -}}
 
 {{ $imgSrc := "" -}}
@@ -24,4 +26,11 @@
   </figure>
 {{ else -}}
   <img class="img-fluid lazyload blur-up" src="{{ $lqip.Permalink }}" data-src="{{ $image.Permalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" alt="{{ $.Text }}">
+{{ end -}}
+
+{{ else -}}
+<figure class="figure">
+  <img src="{{ .Destination | safeURL }}"  alt="{{ $.Text }}" />
+  {{ with $.Title }}<figcaption class="figure-caption">{{ . | safeHTML }}</figcaption>{{ end -}}
+</figure>
 {{ end -}}


### PR DESCRIPTION
Fix for bug - https://github.com/h-enk/doks/issues/535

If a referenced image doesn't exist at build time, it will still create a `figure` with the image so that the alt text will be used instead of breaking the build completely.