### PR TITLE
Adds progress-bar option to topbar nav.

### DIFF
--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -1,0 +1,8 @@
+window.onscroll = function() {move_progressbar()};
+
+function move_progressbar() {
+  var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+  var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  var scrolled = (winScroll / height) * 100;
+  document.getElementById("progress_bar").style.width = scrolled + "%";
+}

--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -81,10 +81,17 @@ $navbar-dark-active-color:          $link-color-dark;
 }
 */
 
-[data-dark-mode] body .navbar,
-[data-dark-mode] body .doks-subnavbar {
+[data-dark-mode] body .navbar {
   background-color: rgba(33, 37, 41, 0.95);
   border-bottom: 1px solid $border-dark;
+}
+
+[data-dark-mode] body .doks-subnavbar {
+  background-color: rgba(33, 37, 41, 0.95);
+}
+
+[data-dark-mode] body .progress-container {
+  background: $border-dark;
 }
 
 [data-dark-mode] body.home .navbar {

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -102,7 +102,6 @@ button#doks-versions {
 
 .doks-subnavbar {
   background-color: rgba(255, 255, 255, 0.95);
-  border-bottom: 1px solid $gray-200;
 }
 
 .doks-subnavbar .nav-link {
@@ -443,3 +442,17 @@ button#doks-versions {
 .dropdown-item:active {
   color: inherit;
 }
+
+.progress-container {
+    margin-top: 8px;
+    width: 100%;
+    height: 1px;
+    background: $gray-200;
+}
+
+.progress-bar {
+  height: 1px;
+  background: $primary;
+  width: 0%;
+}
+

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -444,10 +444,10 @@ button#doks-versions {
 }
 
 .progress-container {
-    margin-top: 8px;
-    width: 100%;
-    height: 1px;
-    background: $gray-200;
+  margin-top: 8px;
+  width: 100%;
+  height: 1px;
+  background: $gray-200;
 }
 
 .progress-bar {
@@ -455,4 +455,3 @@ button#doks-versions {
   background: $primary;
   width: 0%;
 }
-

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -83,6 +83,7 @@ editPage = false
   breadCrumb = false
   highLight = true
   kaTex = false
+  progressbar = true
   collapsibleSidebar = true
   multilingualMode = false
   docsVersioning = false

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -57,6 +57,12 @@
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
+{{ if .Site.Params.options.progressBar -}}
+  {{ $progressbarConfig := resources.Get "js/progressbar.js" -}}
+  {{ $progressbarConfig := $progressbarConfig | js.Build -}}
+  {{ $slice = $slice | append $progressbarConfig -}}
+{{ end -}}
+
 {{ $js := $slice | resources.Concat "main.js" -}}
 
 {{ if eq (hugo.Environment) "development" -}}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -126,6 +126,9 @@
     </button>
 
   </div>
+  <div class="progress-container">
+    <div class="progress-bar" id="progress_bar"></div>
+  </div>
 </nav>
 
 <div class="container-xxl">


### PR DESCRIPTION
This PR adds a progress bar just under the search bar when scrolling down a page:

https://user-images.githubusercontent.com/9611008/147889044-c25538d9-9677-4f53-be26-ed037927ffcf.mov

This feature can be disabled by setting `progressbar` to `false` in `config/_default/params.toml`. The colour of the progress bar is set to `$primary`, which is set to `$purple` by default.