### PR TITLE
Adds a shortcode for the `<details>` tag.

### DIFF
--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -1,0 +1,8 @@
+window.onscroll = function() {move_progressbar()};
+
+function move_progressbar() {
+  var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+  var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  var scrolled = (winScroll / height) * 100;
+  document.getElementById("progress_bar").style.width = scrolled + "%";
+}

--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -81,10 +81,17 @@ $navbar-dark-active-color:          $link-color-dark;
 }
 */
 
-[data-dark-mode] body .navbar,
-[data-dark-mode] body .doks-subnavbar {
+[data-dark-mode] body .navbar {
   background-color: rgba(33, 37, 41, 0.95);
   border-bottom: 1px solid $border-dark;
+}
+
+[data-dark-mode] body .doks-subnavbar {
+  background-color: rgba(33, 37, 41, 0.95);
+}
+
+[data-dark-mode] body .progress-container {
+  background: $border-dark;
 }
 
 [data-dark-mode] body.home .navbar {

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -102,7 +102,6 @@ button#doks-versions {
 
 .doks-subnavbar {
   background-color: rgba(255, 255, 255, 0.95);
-  border-bottom: 1px solid $gray-200;
 }
 
 .doks-subnavbar .nav-link {
@@ -443,3 +442,17 @@ button#doks-versions {
 .dropdown-item:active {
   color: inherit;
 }
+
+.progress-container {
+    margin-top: 8px;
+    width: 100%;
+    height: 1px;
+    background: $gray-200;
+}
+
+.progress-bar {
+  height: 1px;
+  background: $primary;
+  width: 0%;
+}
+

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -444,10 +444,10 @@ button#doks-versions {
 }
 
 .progress-container {
-    margin-top: 8px;
-    width: 100%;
-    height: 1px;
-    background: $gray-200;
+  margin-top: 8px;
+  width: 100%;
+  height: 1px;
+  background: $gray-200;
 }
 
 .progress-bar {
@@ -455,4 +455,3 @@ button#doks-versions {
   background: $primary;
   width: 0%;
 }
-

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -83,6 +83,7 @@ editPage = false
   breadCrumb = false
   highLight = true
   kaTex = false
+  progressbar = true
   collapsibleSidebar = true
   multilingualMode = false
   docsVersioning = false

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -57,6 +57,12 @@
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
+{{ if .Site.Params.options.progressBar -}}
+  {{ $progressbarConfig := resources.Get "js/progressbar.js" -}}
+  {{ $progressbarConfig := $progressbarConfig | js.Build -}}
+  {{ $slice = $slice | append $progressbarConfig -}}
+{{ end -}}
+
 {{ $js := $slice | resources.Concat "main.js" -}}
 
 {{ if eq (hugo.Environment) "development" -}}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -126,6 +126,9 @@
     </button>
 
   </div>
+  <div class="progress-container">
+    <div class="progress-bar" id="progress_bar"></div>
+  </div>
 </nav>
 
 <div class="container-xxl">

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,0 +1,6 @@
+<p>
+    <details>
+        <summary>{{ (.Get 0) | markdownify }}</summary>
+        {{ .Inner | markdownify }}
+    </details>
+</p>


### PR DESCRIPTION
This PR simply adds a shortcode to use the `<details`> HTML tag. The tag is used something like this:

```markdown
{{< details "Recipes" >}}
Get instructions on how to accomplish common tasks with Doks. [Recipes →](https://getdoks.org/docs/recipes/project-configuration/)
{{< /details >}}
```

They look like this when closed:

![image](https://user-images.githubusercontent.com/9611008/149443998-71d01368-d0f1-467a-ae77-c2e76b367e82.png)

And then they look like this when open:

![image](https://user-images.githubusercontent.com/9611008/149444079-71778f41-d7c2-4d74-8479-674841092917.png)

Might need to add some styling so that they stand out a bit from regular text.
