### PR TITLE
feat: edit link docs repo subpath

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -66,7 +66,7 @@ alertDismissable = true
 alertText = "Introducing the Doks child theme, several DX + UX updates, and more! <a class=\"alert-link stretched-link\" href=\"https://getdoks.org/blog/doks-v0.2/\">Check out Doks v0.2</a>"
 
 # Edit Page
-# repoHost [Github | Gitea | GitLab | Bitbucket ] is used for building the edit link based on git hoster
+# repoHost [Github | Gitea | GitLab | Bitbucket | BitbucketServer ] is used for building the edit link based on git hoster
 repoHost = "GitHub"
 #repoHost = "Gitea"
 docsRepo = "https://github.com/h-enk/doks"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -66,11 +66,12 @@ alertDismissable = true
 alertText = "Introducing the Doks child theme, several DX + UX updates, and more! <a class=\"alert-link stretched-link\" href=\"https://getdoks.org/blog/doks-v0.2/\">Check out Doks v0.2</a>"
 
 # Edit Page
-# repoHost [Github | Gitea | GitLab] is used for building the edit link based on git hoster
+# repoHost [Github | Gitea | GitLab | Bitbucket ] is used for building the edit link based on git hoster
 repoHost = "GitHub"
 #repoHost = "Gitea"
 docsRepo = "https://github.com/h-enk/doks"
 docsRepoBranch = "master"
+docsRepoSubPath = ""
 editPage = false
 lastMod = false
 

--- a/layouts/partials/main/edit-page.html
+++ b/layouts/partials/main/edit-page.html
@@ -1,5 +1,4 @@
 {{ $parts := slice .Site.Params.docsRepo }}
-{{ $filePath := replace .File.Path "\\" "/" }}
 
 {{ if (eq .Site.Params.repoHost "GitHub") }}
   {{ $parts = $parts | append "blob" .Site.Params.docsRepoBranch }}
@@ -8,6 +7,8 @@
 {{ else if (eq .Site.Params.repoHost "GitLab") }}
   {{ $parts = $parts | append "-/blob" .Site.Params.docsRepoBranch }}
 {{ else if (eq .Site.Params.repoHost "Bitbucket") }}
+  {{ $parts = $parts | append "src" .Site.Params.docsRepoBranch }}
+{{ else if (eq .Site.Params.repoHost "BitbucketServer") }}
   {{ $parts = $parts | append "browse" .Site.Params.docsRepoBranch }}
 {{ end }}
 
@@ -16,6 +17,8 @@
     {{ $parts = $parts | append .Site.Params.docsRepoSubPath }}
   {{ end }}
 {{ end }}
+
+{{ $filePath := replace .File.Path "\\" "/" }}
 
 {{ if .Site.Params.options.multilingualMode }}
   {{ $parts = $parts | append "content" .Lang $filePath }}

--- a/layouts/partials/main/edit-page.html
+++ b/layouts/partials/main/edit-page.html
@@ -1,16 +1,29 @@
+{{ $parts := slice .Site.Params.docsRepo }}
 {{ $filePath := replace .File.Path "\\" "/" }}
-{{ $editPath := "null" }}
 
 {{ if (eq .Site.Params.repoHost "GitHub") }}
-  {{ $editPath = "/blob/" }}
+  {{ $parts = $parts | append "blob" .Site.Params.docsRepoBranch }}
 {{ else if (eq .Site.Params.repoHost "Gitea") }}
-  {{ $editPath = "/_edit/" }}
+  {{ $parts = $parts | append "_edit" .Site.Params.docsRepoBranch }}
 {{ else if (eq .Site.Params.repoHost "GitLab") }}
-  {{ $editPath = "/-/blob/" }}
+  {{ $parts = $parts | append "-/blob" .Site.Params.docsRepoBranch }}
+{{ else if (eq .Site.Params.repoHost "Bitbucket") }}
+  {{ $parts = $parts | append "browse" .Site.Params.docsRepoBranch }}
 {{ end }}
 
-{{ $contentPath := print .Site.Params.docsRepo $editPath .Site.Params.docsRepoBranch "/content/" }}
-{{ $url := print $contentPath .Lang "/" $filePath }}
+{{ if isset .Site.Params "docsreposubpath" }}
+  {{ if not (eq .Site.Params.docsRepoSubPath "") }}
+    {{ $parts = $parts | append .Site.Params.docsRepoSubPath }}
+  {{ end }}
+{{ end }}
+
+{{ if .Site.Params.options.multilingualMode }}
+  {{ $parts = $parts | append "content" .Lang $filePath }}
+{{ else }}
+  {{ $parts = $parts | append "content" $filePath }}
+{{ end }}
+
+{{ $url := delimit $parts "/" }}
 
 <div class="edit-page">
   <a href="{{ $url }}">


### PR DESCRIPTION
Can be used if the folder with your content is in a subfolder so if your project wishes to contain code and docs in the same repo it's convenient to do so. Additionally includes some refactoring in the edit-page.html logic to make it  easier to manage. Also added Bitbucket and BitbucketServer repo types.