### PR TITLE
[#604] Allow Firefox on macOS to see italic text.

### DIFF
--- a/assets/scss/common/_fonts.scss
+++ b/assets/scss/common/_fonts.scss
@@ -41,7 +41,7 @@
   font-weight: 400;
   font-display: swap;
   src:
-    local("Jost"),
+    local("Jost-Italic"),
     url("fonts/vendor/jost/jost-v4-latin-italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -53,7 +53,7 @@
   font-weight: 500;
   font-display: swap;
   src:
-    local("Jost"),
+    local("Jost-Italic"),
     url("fonts/vendor/jost/jost-v4-latin-500italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-500italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -65,7 +65,7 @@
   font-weight: 700;
   font-display: swap;
   src:
-    local("Jost"),
+    local("Jost-Italic"),
     url("fonts/vendor/jost/jost-v4-latin-700italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-700italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }

--- a/assets/scss/common/_fonts.scss
+++ b/assets/scss/common/_fonts.scss
@@ -5,11 +5,10 @@
   font-weight: 400;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
-    local("Jost Regular Regular"),   /* Full Name */
-    local("Jost-Regular"),           /* PostScript name */
-
-    /* indestructible Jost* */
+    // Google Fonts Jost
+    local("Jost Regular Regular"),   // Full Name
+    local("Jost-Regular"),           // PostScript name
+    // indestructible Jost*
     local("Jost* Book"),
     local("Jost-Book"),
     url("fonts/vendor/jost/jost-v4-latin-regular.woff2") format("woff2"),
@@ -23,11 +22,10 @@
   font-weight: 500;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
+    // Google Fonts Jost
     local("Jost Regular Medium"),
     local("JostRoman-Medium"),
-
-    /* indestructible Jost* */
+    // indestructible Jost*
     local("Jost* Medium"),
     local("Jost-Medium"),
     url("fonts/vendor/jost/jost-v4-latin-500.woff2") format("woff2"),
@@ -41,11 +39,10 @@
   font-weight: 700;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
+    // Google Fonts Jost
     local("Jost Regular Bold"),
     local("JostRoman-Bold"),
-
-    /* indestructible Jost* */
+    // indestructible Jost*
     local("Jost* Bold"),
     local("Jost-Bold"),
     url("fonts/vendor/jost/jost-v4-latin-700.woff2") format("woff2"),
@@ -59,11 +56,10 @@
   font-weight: 400;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
+    // Google Fonts Jost
     local("Jost Italic Italic"),
     local("Jost-Italic"),
-
-    /* indestructible Jost* */
+    // indestructible Jost*
     local("Jost* BookItalic"),
     local("Jost-BookItalic"),
     url("fonts/vendor/jost/jost-v4-latin-italic.woff2") format("woff2"),
@@ -77,11 +73,10 @@
   font-weight: 500;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
+    // Google Fonts Jost
     local("Jost Italic Medium Italic"),
     local("JostItalic-Medium"),
-
-    /* indestructible Jost* */
+    // indestructible Jost*
     local("Jost* Medium Italic"),
     local("Jost-MediumItalic"),
     url("fonts/vendor/jost/jost-v4-latin-500italic.woff2") format("woff2"),
@@ -95,11 +90,10 @@
   font-weight: 700;
   font-display: swap;
   src:
-    /* Google Fonts Jost */
+    // Google Fonts Jost
     local("Jost Italic Bold Italic"),
     local("JostItalic-Bold"),
-
-    /* indestructible Jost* */
+    // indestructible Jost*
     local("Jost* Bold Italic"),
     local("Jost-BoldItalic"),
     url("fonts/vendor/jost/jost-v4-latin-700italic.woff2") format("woff2"),

--- a/assets/scss/common/_fonts.scss
+++ b/assets/scss/common/_fonts.scss
@@ -5,7 +5,13 @@
   font-weight: 400;
   font-display: swap;
   src:
-    local("Jost"),
+    /* Google Fonts Jost */
+    local("Jost Regular Regular"),   /* Full Name */
+    local("Jost-Regular"),           /* PostScript name */
+
+    /* indestructible Jost* */
+    local("Jost* Book"),
+    local("Jost-Book"),
     url("fonts/vendor/jost/jost-v4-latin-regular.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -17,7 +23,13 @@
   font-weight: 500;
   font-display: swap;
   src:
-    local("Jost"),
+    /* Google Fonts Jost */
+    local("Jost Regular Medium"),
+    local("JostRoman-Medium"),
+
+    /* indestructible Jost* */
+    local("Jost* Medium"),
+    local("Jost-Medium"),
     url("fonts/vendor/jost/jost-v4-latin-500.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -29,7 +41,13 @@
   font-weight: 700;
   font-display: swap;
   src:
-    local("Jost"),
+    /* Google Fonts Jost */
+    local("Jost Regular Bold"),
+    local("JostRoman-Bold"),
+
+    /* indestructible Jost* */
+    local("Jost* Bold"),
+    local("Jost-Bold"),
     url("fonts/vendor/jost/jost-v4-latin-700.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -41,7 +59,13 @@
   font-weight: 400;
   font-display: swap;
   src:
+    /* Google Fonts Jost */
+    local("Jost Italic Italic"),
     local("Jost-Italic"),
+
+    /* indestructible Jost* */
+    local("Jost* BookItalic"),
+    local("Jost-BookItalic"),
     url("fonts/vendor/jost/jost-v4-latin-italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -53,7 +77,13 @@
   font-weight: 500;
   font-display: swap;
   src:
-    local("Jost-Italic"),
+    /* Google Fonts Jost */
+    local("Jost Italic Medium Italic"),
+    local("JostItalic-Medium"),
+
+    /* indestructible Jost* */
+    local("Jost* Medium Italic"),
+    local("Jost-MediumItalic"),
     url("fonts/vendor/jost/jost-v4-latin-500italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-500italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
@@ -65,7 +95,13 @@
   font-weight: 700;
   font-display: swap;
   src:
-    local("Jost-Italic"),
+    /* Google Fonts Jost */
+    local("Jost Italic Bold Italic"),
+    local("JostItalic-Bold"),
+
+    /* indestructible Jost* */
+    local("Jost* Bold Italic"),
+    local("Jost-BoldItalic"),
     url("fonts/vendor/jost/jost-v4-latin-700italic.woff2") format("woff2"),
     url("fonts/vendor/jost/jost-v4-latin-700italic.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }


### PR DESCRIPTION
I've tested this by changing the _rendered CSS_ as below on Safari, Firefox and Chrome on macOS 11.6.2. I haven't actually run Hugo with the below change, because I don't have a doks install set up to develop with. But I hope it's simple enough to verify that this change does what's expected.

Here's [the relevant MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src). MDN is actually kind of confusing here. The formal syntax says that you should use a font family name inside `local()`, but the code in two other places say you should actually use the font face name. And the [example](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#examples) is quite explicit that the PostScript name is an acceptable value here.

It looks like MDN got it wrong, because the [CSS spec](https://www.w3.org/TR/css-fonts-3/#font-face-name-value) is quite clear:

>  The locally-installed <font-face-name> argument to local() is a format-specific string that uniquely identifies a single font face within a larger family.

Looks like I'll have to file an MDN bug now too, LOL! [Update: [bug filed](https://github.com/mdn/content/issues/12347).]

Note that, unsurprisingly, all the bold text goes away when I change the `local()` specifier to the PostScript name of `Jost-Regular`. I guess there would need to be a few more `@font-face` rules to account for that.