### PR TITLE
fix(layouts): use the permalink instead of url

### DIFF
--- a/layouts/partials/sidebar/auto-default-menu.html
+++ b/layouts/partials/sidebar/auto-default-menu.html
@@ -18,18 +18,18 @@
                 <ul class="list-unstyled ms-3">
                   {{ range .Pages }}
                     {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                    <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                    <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
                   {{ end }}
                 </ul>
               {{ else }}
                 {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
               {{ end }}
             {{ end }}
           </ul>
         {{ else }}
           {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-          <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+          <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
         {{ end }}
       {{ end }}
     </ul>

--- a/layouts/partials/sidebar/manual-collapsible-menu.html
+++ b/layouts/partials/sidebar/manual-collapsible-menu.html
@@ -33,7 +33,7 @@
                                   {{ range .Children -}}
                                     {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
                                     {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-                                    <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                                    <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
                                   {{ end -}}
                                   </ul>
                                 </div>
@@ -42,7 +42,7 @@
                           {{ else -}}
                             {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
                             {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-                            <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                            <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
                           {{ end -}}
                         {{ end -}}
                       </ul>
@@ -52,7 +52,7 @@
               {{ else -}}
                 {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
                 {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-                <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
               {{ end -}}
             {{ end -}}
           </ul>

--- a/layouts/partials/sidebar/manual-default-menu.html
+++ b/layouts/partials/sidebar/manual-default-menu.html
@@ -18,14 +18,14 @@
                       {{ range .Children -}}
                         {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
                         {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-                        <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                        <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
                       {{ end -}}
                     </ul>
                   {{ end -}}
                 {{ else -}}
                   {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
                   {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-                  <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+                  <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
                 {{ end -}}
               {{ end -}}
             </ul>
@@ -33,7 +33,7 @@
         {{ else -}}
           {{- $active := or ($currentPage.IsMenuCurrent $section .) ($currentPage.HasMenuCurrent $section .) -}}
           {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-          <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+          <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
         {{ end -}}
       {{ end -}}
     </ul>


### PR DESCRIPTION
## Summary

Removes usage of deprecated .URL parameter, and brings the menus usage of .Permakink for href's to be consistent.

## Basic example

I don't think a screenshot is relevant. But I modeled these changes after the usage of .Permalink here: https://github.com/h-enk/doks/blob/master/layouts/partials/sidebar/auto-collapsible-menu.html#L41

## Motivation

Removes a deprecated usage of a parameter, suppresses an error, and makes the menu's slightly more consistent. 

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
