### PR TITLE
fix(flexsearch): separate chain of calls into statements

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -97,8 +97,8 @@ Source:
   {{ $list := (where .Site.Pages "Section" "docs") -}}
   {{ $len := (len $list) -}}
 
-  index.add(
-    {{ range $index, $element := $list -}}
+  {{ range $index, $element := $list -}}
+    index.add(
       {
         id: {{ $index }},
         href: "{{ .RelPermalink }}",
@@ -109,12 +109,9 @@ Source:
           description: {{ .Summary | plainify | jsonify }},
         {{ end -}}
         content: {{ .Plain | jsonify }}
-      })
-      {{ if ne (add $index 1) $len -}}
-        .add(
-      {{ end -}}
-    {{ end -}}
-  ;
+      }
+    );
+  {{ end -}}
 
   search.addEventListener('input', show_results, true);
 


### PR DESCRIPTION
This makes the search bar continue to work when many (2000+) pages are added.

## Summary

This adjusts the way in which the search index is built so that the call stack is not exceeded on some browsers (see #738 for browser compatibility). I'm not familiar with Hugo templating so if there's a preferred way, we can go that route!

## Basic example

Previously, the compiled template would add to the array `index` by chaining `.add()` calls.

```js
index.add(
{
  id: 3,
  href: "/docs/prologue/doc1/",
  title: "doc1",
  description: "Doks comes with commands for common tasks.",
  content: ""
})
.add(
{
  id: 4,
  href: "/docs/prologue/doc10/",
  title: "doc10",
  description: "Doks comes with commands for common tasks.",
  content: ""
})
.add(
{
  id: 5,
  href: "/docs/prologue/doc100/",
  title: "doc100",
  description: "Doks comes with commands for common tasks.",
  content: ""
})
...
```

Now, this PR would make the resulting template add to `index` without chaining, something like:
    
```js
index.add(
  {
    id: 3,
    href: "/docs/prologue/doc1/",
    title: "doc1",
    description: "Doks comes with commands for common tasks.",
    content: ""
  }
);
index.add(
  {
    id: 4,
    href: "/docs/prologue/doc10/",
    title: "doc10",
    description: "Doks comes with commands for common tasks.",
    content: ""
  }
);
index.add(
  {
    id: 5,
    href: "/docs/prologue/doc100/",
    title: "doc100",
    description: "Doks comes with commands for common tasks.",
    content: ""
  }
);
...
```

## Motivation

Closes #738

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
