### PR TITLE
Use SVG favicon if it exists

### DIFF
--- a/layouts/partials/head/favicons.html
+++ b/layouts/partials/head/favicons.html
@@ -1,5 +1,8 @@
 <meta name="theme-color" content="{{ $.Site.Params.themeColor }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | absURL }}">
+{{ if os.FileExists "static/favicon.svg" }}
+  <link rel="icon" type="image/svg+xml" href="{{ "favicon.svg" | absURL }}">
+{{ end }}
 <link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon-32x32.png" | absURL }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | absURL }}">
 <link rel="manifest" crossorigin="use-credentials" href="{{ "site.webmanifest" | absURL }}">


### PR DESCRIPTION
## Summary

Use SVG favicon if "static/favicon.svg" exists.

## Basic example

1. Add "favicon.svg" file to "static" directory
2. `hugo serve`
3. SVG favicon is used on `localhost:1313://`.

## Motivation

SVG favicon is useful since we should manage only one image, while png favicon is varied like 16x16 and 32x32.

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
