### PR TITLE
Add custom-head.html

### DIFF
--- a/layouts/partials/head/custom-head.html
+++ b/layouts/partials/head/custom-head.html
@@ -1,0 +1,1 @@
+<!-- Custom head -->

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -7,4 +7,5 @@
   {{ block "head/stylesheet" . }}{{ partial "head/stylesheet.html" . }}{{ end }}
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}
   {{ block "head/favicons" . }}{{ partial "head/favicons.html" . }}{{ end }}
+  {{ block "head/custom-head" . }}{{ partial "head/custom-head.html" . }}{{ end }}
 </head>


### PR DESCRIPTION
## Summary

Add empty file named `partials/head/custom-head.html`, which is "partial" called from `partials/head/head.html`

## Basic example

```html
<!-- Write custom head code in custom-head.html on user repo generated from doks-child-theme -->
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" integrity="sha512-KfkfwYDsLkIlwQp6LFnl8zNdLGxu9YAA1QvwINks4PhcElQSvqcyVLLD9aMhXd13uQjoXtEKNosOWaZqXgel0g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
```

## Motivation

`doks-child-theme` is hard to customize to import some external code like code from CDN.
Even it is not for deep custom, flexible `head` can be allowed, I think.

In addition, some user-adding tags in `<head>` cannot be categorized to existing "partials" in head, such as "favicons.html", "seo.html". So custom-head.html is useful for doks user (i.e. non-doks-child-theme user).

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
