### PR TITLE
fix(layouts): index.redirects truncates newline

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,8 +1,8 @@
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
-{{ . }} {{ $p.RelPermalink -}}
+{{ . }} {{ $p.RelPermalink }}
 {{- end }}
-{{- end -}}
+{{- end }}
 
 # /docs/1.0/prologue/   /docs/1.0/prologue/introduction/
 # /docs/1.0/help/       /docs/1.0/help/how-to-update/


### PR DESCRIPTION
## Summary

This fixes an issue where the generation of aliases may remove newlines erroneously moving subsequent lines to the same line as the last alias or otherwise mangle the output.

## Basic example

Can be  tested in a short-code with the following content rendered in a fence (you can also see the output of the original using this method just with the original template; you can also replace `.Aliases` with `dict` to see what it does with an empty enumerable I believe):

```html
start
{{- range $p := .Site.Pages }}
{{- range .Aliases }}
{{ . }} {{ $p.RelPermalink }}
{{- end }}
{{- end }}
end
```

## Motivation

This prevents an error in netlify about a redirect which is improperly formatted.

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
