### PR TITLE
fix(menus): sort pages and sections by default order

### DIFF
--- a/content/en/docs/help/_index.md
+++ b/content/en/docs/help/_index.md
@@ -6,4 +6,5 @@ date: 2020-10-06T08:49:15+00:00
 lastmod: 2020-10-06T08:49:15+00:00
 draft: false
 images: []
+weight: 600
 ---

--- a/content/en/docs/prologue/_index.md
+++ b/content/en/docs/prologue/_index.md
@@ -6,4 +6,5 @@ date: 2020-10-06T08:48:45+00:00
 lastmod: 2020-10-06T08:48:45+00:00
 draft: false
 images: []
+weight: 100
 ---

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -3,7 +3,7 @@
   {{ $currentPage := . -}}
   {{ $section := $currentPage.Section -}}
   {{ range (where .Site.Sections "Section" "in" $section) }}
-    {{ range .Sections.ByWeight.Reverse }}
+    {{ range .Sections }}
       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
       <li class="mb-1">
         <button class="btn btn-toggle align-items-center rounded collapsed" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .Title }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">

--- a/layouts/partials/sidebar/auto-default-menu.html
+++ b/layouts/partials/sidebar/auto-default-menu.html
@@ -2,7 +2,7 @@
 {{ $currentPage := . -}}
 {{ $section := $currentPage.Section -}}
 {{ range (where .Site.Sections "Section" "in" $section) }}
-  {{ range .Sections.ByWeight.Reverse }}
+  {{ range .Sections }}
     {{ $active := in $currentPage.RelPermalink .RelPermalink }}
     <h3 class="h6 text-uppercase mb-2">{{ .Title }}</h3>
     <ul class="list-unstyled">


### PR DESCRIPTION
This restores the default hugo sorting behaviour.

Fixes #781

## Summary

This restores the default sorting behavior of sections. It will require that users using the auto menus include a weight in the `_index.md` of each sub-section.

## Basic example

![image](https://user-images.githubusercontent.com/3903683/175194188-3335dedb-773d-4300-97da-03e41412d206.png)


## Motivation

See https://github.com/h-enk/doks/issues/781#issuecomment-1154968981

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
