### PR TITLE
fix: build fails when figure has link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/core": "^7.18",
         "@babel/preset-env": "^7.18",
         "@fullhuman/postcss-purgecss": "^4.1",
-        "@hyas/images": "^0.2.1",
+        "@hyas/images": "^0.2.2",
         "auto-changelog": "^2.4",
         "autoprefixer": "^10.4",
         "bootstrap": "^5.2.0-beta1",
@@ -1757,9 +1757,9 @@
       "dev": true
     },
     "node_modules/@hyas/images": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.1.tgz",
-      "integrity": "sha512-OESrxH316UeTbgpDJsRS1fnoZzOIGh2+evhaaXUBrDXhg+5YT1myR7SKf00bzi1fSbQlw5+JyOmNLll/JNHxoQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.2.tgz",
+      "integrity": "sha512-m6sYlR+iNAQBhbt+AKekRsXPrKff+UpE1/XsGqNIi9Ptb8ZdRiv/bgY1ZCdKAf6hNop1OT1bbS5WkP9wo0wb+w==",
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -8197,9 +8197,9 @@
       "dev": true
     },
     "@hyas/images": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.1.tgz",
-      "integrity": "sha512-OESrxH316UeTbgpDJsRS1fnoZzOIGh2+evhaaXUBrDXhg+5YT1myR7SKf00bzi1fSbQlw5+JyOmNLll/JNHxoQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.2.tgz",
+      "integrity": "sha512-m6sYlR+iNAQBhbt+AKekRsXPrKff+UpE1/XsGqNIi9Ptb8ZdRiv/bgY1ZCdKAf6hNop1OT1bbS5WkP9wo0wb+w==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/core": "^7.18",
     "@babel/preset-env": "^7.18",
     "@fullhuman/postcss-purgecss": "^4.1",
-    "@hyas/images": "^0.2.1",
+    "@hyas/images": "^0.2.2",
     "auto-changelog": "^2.4",
     "autoprefixer": "^10.4",
     "bootstrap": "^5.2.0-beta1",


### PR DESCRIPTION
This should be understood as communication that I believe the issue is fixed with the changes made by @h-enk and @danielfdickinson. I did not personally fix this I'm just bumping the dep.

This fixes an issue where if a figure image has a link the hugo build fails.

Fixes #820

## Summary

Brief explanation of the proposed changes.

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
