### PR TITLE
fix: navbar-brand href now links to the BaseURL instead of `/`

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -11,7 +11,7 @@
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
   <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main navigation">
 
-    <a class="navbar-brand order-0" href="{{ "/" | relLangURL }}" aria-label="{{ .Site.Params.Title }}">
+    <a class="navbar-brand order-0" href="{{ .Site.BaseURL | relLangURL }}" aria-label="{{ .Site.Params.Title }}">
       {{ .Site.Params.Title }}
     </a>
 


### PR DESCRIPTION
## Summary

Currently, the navbar-brand links to "/".
Given that BaseURL is configurabe, I think this is probably a bug.

## Basic example

before:

```html
<a class="navbar-brand order-0" href="/" aria-label="Foo">Foo</a>
```

after:
```html
<a class="navbar-brand order-0" href="/foo" aria-label="Foo">Foo</a>
```

## Motivation

In some instances, a URL like `/` is not possible. This is the case for example for websites like GitLab pages which serve under `user.pages.instance.tld/projectname`

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
      For some reason my IDE is not allowing me to edit commit messages, but this is probably not that big of an issue for this PR, as you can just edit the commit message via squashing this PR into main 😉 
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
